### PR TITLE
fix javadoc generation with OpenJDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@
                         </goals>
                         <configuration>
                             <additionalparam>-Xdoclint:none</additionalparam>
+                            <source>1.8</source>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>edu.stanford.protege</groupId>
     <artifactId>de-derivo-sparqldlapi</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -109,7 +109,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -123,7 +123,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/java/de/derivo/sparqldlapi/QueryEngine.java
+++ b/src/main/java/de/derivo/sparqldlapi/QueryEngine.java
@@ -34,7 +34,7 @@ public abstract class QueryEngine
 	 * 
 	 * @param manager An OWLOntologyManager instance of OWLAPI v3
 	 * @param reasoner An OWLReasoner instance.
-	 * @param strictMode If strict mode is enabled the query engine will throw a QueryEngineException if data types withing the query are not correct (e.g. Class(URI_OF_AN_INDIVIDUAL))
+	 * @param strict If strict mode is enabled the query engine will throw a QueryEngineException if data types withing the query are not correct (e.g. Class(URI_OF_AN_INDIVIDUAL))
 	 * @return an instance of QueryEngine
 	 */
 	public static QueryEngine create(OWLOntologyManager manager, OWLReasoner reasoner, boolean strict)

--- a/src/main/java/de/derivo/sparqldlapi/impl/QueryImpl.java
+++ b/src/main/java/de/derivo/sparqldlapi/impl/QueryImpl.java
@@ -59,7 +59,7 @@ public class QueryImpl extends Query
 	/**
 	 * Remove a result variable from the query.
 	 * 
-	 * @param atom
+	 * @param arg
 	 * @return
 	 */
 	public boolean removeResultVar(QueryArgument arg)


### PR DESCRIPTION
Most important change is to add <source>1.8</source> to the maven-javadoc-plugin configuration, as otherwise it failed with:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.301 s
[INFO] Finished at: 2019-09-21T06:25:55Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadocs) on project de-derivo-sparqldlapi: MavenReportException: Error while creating archive:
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/7/docs/api/ are in the unnamed module.
[ERROR]
[ERROR] Command line was: /usr/lib/jvm/java-11-openjdk-amd64/bin/javadoc @options @packages
[ERROR]
[ERROR] Refer to the generated Javadoc files in '/mnt/c/Users/wolskia/privat/sparql-dl-api/target/apidocs' dir.
[ERROR]
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

The updates of the maven plugins were not necessary, but as I was working in that area I did it as well.